### PR TITLE
Improved `get_forcis_db`: download files only once and add a timeout for slow connections

### DIFF
--- a/R/gets.R
+++ b/R/gets.R
@@ -10,11 +10,11 @@
 #' @param version a `character` of length 1. The version number of the 
 #'   FORCIS database. Default is the latest version.
 #'
-#' @param overwrite a `Boolean`. Override the downloaded files of  
-#'   FORCIS database. Default is FALSE.
+#' @param overwrite a `logical`. If `TRUE` it will override the downloaded 
+#'   files of the FORCIS database. Default is `FALSE`.
 #'
-#'@param timeout a `int`. The timeout for downloading files from  
-#'   FORCIS database. Default is 60.
+#' @param timeout a `integer`. The timeout for downloading files from the 
+#'   FORCIS database. Default is `60`.
 #'
 #' @return No return value. The five `csv` files will be saved in the `path`
 #' folder.
@@ -38,7 +38,7 @@
 #' list.files(path_to_save_db)
 #' }
 
-get_forcis_db <- function(path      = ".", version = forcis_db_version(), 
+get_forcis_db <- function(path = ".", version = forcis_db_version(), 
                           overwrite = FALSE, timeout = 60) {
   
   ## Check args ----
@@ -289,14 +289,17 @@ download_csv <- function(path, file, overwrite = FALSE, timeout = 60) {
   download_url <- paste0(forcis_db_url(), file, "?download=1")
   
   if (!overwrite && file.exists(destination)) {
-    message("File already exists. Skipping download.")
+    message("The file '", file, "' already exists. If you want to download ",
+            "again this file please use the argument 'overwrite'.")
     return(invisible(NULL))
   }
   
   ## Download the file if 'overwrite' is TRUE or it doesn't exist ----
   
   # change timeout for large file and slow connection
-  options(timeout= max(timeout, getOption('timeout')))
+  user_opts <- options()
+  on.exit(options(user_opts))
+  options(timeout = max(timeout, getOption("timeout")))
   
   tryCatch({
     utils::download.file(url = download_url, destfile = destination, mode = "wb")

--- a/man/get_forcis_db.Rd
+++ b/man/get_forcis_db.Rd
@@ -18,11 +18,11 @@ database will be saved.}
 \item{version}{a \code{character} of length 1. The version number of the
 FORCIS database. Default is the latest version.}
 
-\item{overwrite}{a \code{Boolean}. Override the downloaded files of
-FORCIS database. Default is FALSE.}
+\item{overwrite}{a \code{logical}. If \code{TRUE} it will override the downloaded
+files of the FORCIS database. Default is \code{FALSE}.}
 
-\item{timeout}{a \code{int}. The timeout for downloading files from
-FORCIS database. Default is 60.}
+\item{timeout}{a \code{integer}. The timeout for downloading files from the
+FORCIS database. Default is \code{60}.}
 }
 \value{
 No return value. The five \code{csv} files will be saved in the \code{path}

--- a/man/get_forcis_db.Rd
+++ b/man/get_forcis_db.Rd
@@ -4,7 +4,12 @@
 \alias{get_forcis_db}
 \title{Download the entire FORCIS database}
 \usage{
-get_forcis_db(path = ".", version = forcis_db_version())
+get_forcis_db(
+  path = ".",
+  version = forcis_db_version(),
+  overwrite = FALSE,
+  timeout = 60
+)
 }
 \arguments{
 \item{path}{a \code{character} of length 1. The folder in which the FORCIS
@@ -12,6 +17,12 @@ database will be saved.}
 
 \item{version}{a \code{character} of length 1. The version number of the
 FORCIS database. Default is the latest version.}
+
+\item{overwrite}{a \code{Boolean}. Override the downloaded files of
+FORCIS database. Default is FALSE.}
+
+\item{timeout}{a \code{int}. The timeout for downloading files from
+FORCIS database. Default is 60.}
 }
 \value{
 No return value. The five \code{csv} files will be saved in the \code{path}


### PR DESCRIPTION
## Fixes for `get_forcis_db`

I faced some minor issues while testing `get_forcis_db`:

* The default timeout for `download.file()` is too low for large files and slow internet connections.
* The function downloads the files every time the R script is executed, even if the files already exist.

To fix these issues, I added two new arguments to the function:

* `overwrite`: A boolean value that indicates whether to overwrite existing files. The default value is `FALSE`, which means that the function will skip downloading files that already exist.
* `timeout`: An integer value that specifies the timeout for `download.file()`. The default value is 60 seconds.

I also added a check to the function to delete any temporary files that were created if the download fails.

I believe these changes will make `get_forcis_db` more user-friendly and reliable.

### Example
```r
library(forcis)

# Set the overwrite argument to TRUE
get_forcis_db(overwrite = TRUE)

# Set the timeout argument to 300 seconds
get_forcis_db(timeout = 300)
```
