### PR TITLE
rOpenSci review: Rename global options

### DIFF
--- a/R/download_forcis_db.R
+++ b/R/download_forcis_db.R
@@ -18,11 +18,11 @@
 #'   version of the database.
 #'
 #' @param check_for_update a `logical`. If `TRUE` (default) the function will
-#'   check if a newer version of the FORCIS database is available on Zenodo and
-#'   will print an informative message. Note that this argument can be handle
-#'   with the global option `check_for_update`. For example, if user calls
-#'   `options(check_for_update = FALSE)`, the message to download the latest
-#'   version will be disabled for the current R session.
+#'   check if a newer version of the FORCIS database is available on Zenodo
+#'   and will print an informative message. Note that this argument can be
+#'   handle with the global option `forcis_check_for_update`. For example, if
+#'   user calls `options(forcis_check_for_update = FALSE)`, the message to
+#'   download the latest version will be disabled for the current R session.
 #'
 #' @param overwrite a `logical`. If `TRUE` it will override the downloaded
 #'   files of the FORCIS database. Default is `FALSE`.
@@ -71,7 +71,7 @@
 download_forcis_db <- function(
   path = ".",
   version = options()$"forcis_version",
-  check_for_update = options()$"check_for_update",
+  check_for_update = options()$"forcis_check_for_update",
   overwrite = FALSE,
   timeout = 60
 ) {

--- a/R/read_cpr_north_data.R
+++ b/R/read_cpr_north_data.R
@@ -4,7 +4,7 @@
 read_cpr_north_data <- function(
   path = ".",
   version = options()$"forcis_version",
-  check_for_update = options()$"check_for_update"
+  check_for_update = options()$"forcis_check_for_update"
 ) {
   ## Check args ----
 

--- a/R/read_cpr_south_data.R
+++ b/R/read_cpr_south_data.R
@@ -4,7 +4,7 @@
 read_cpr_south_data <- function(
   path = ".",
   version = options()$"forcis_version",
-  check_for_update = options()$"check_for_update"
+  check_for_update = options()$"forcis_check_for_update"
 ) {
   ## Check args ----
 

--- a/R/read_plankton_nets_data.R
+++ b/R/read_plankton_nets_data.R
@@ -50,7 +50,7 @@ NULL
 read_plankton_nets_data <- function(
   path = ".",
   version = options()$"forcis_version",
-  check_for_update = options()$"check_for_update"
+  check_for_update = options()$"forcis_check_for_update"
 ) {
   ## Check args ----
 

--- a/R/read_pump_data.R
+++ b/R/read_pump_data.R
@@ -4,7 +4,7 @@
 read_pump_data <- function(
   path = ".",
   version = options()$"forcis_version",
-  check_for_update = options()$"check_for_update"
+  check_for_update = options()$"forcis_check_for_update"
 ) {
   ## Check args ----
 

--- a/R/read_sediment_trap_data.R
+++ b/R/read_sediment_trap_data.R
@@ -4,7 +4,7 @@
 read_sediment_trap_data <- function(
   path = ".",
   version = options()$"forcis_version",
-  check_for_update = options()$"check_for_update"
+  check_for_update = options()$"forcis_check_for_update"
 ) {
   ## Check args ----
 

--- a/man/download_forcis_db.Rd
+++ b/man/download_forcis_db.Rd
@@ -7,7 +7,7 @@
 download_forcis_db(
   path = ".",
   version = options()$forcis_version,
-  check_for_update = options()$check_for_update,
+  check_for_update = options()$forcis_check_for_update,
   overwrite = FALSE,
   timeout = 60
 )
@@ -26,11 +26,11 @@ for the current R session. Note that it is recommended to use the latest
 version of the database.}
 
 \item{check_for_update}{a \code{logical}. If \code{TRUE} (default) the function will
-check if a newer version of the FORCIS database is available on Zenodo and
-will print an informative message. Note that this argument can be handle
-with the global option \code{check_for_update}. For example, if user calls
-\code{options(check_for_update = FALSE)}, the message to download the latest
-version will be disabled for the current R session.}
+check if a newer version of the FORCIS database is available on Zenodo
+and will print an informative message. Note that this argument can be
+handle with the global option \code{forcis_check_for_update}. For example, if
+user calls \code{options(forcis_check_for_update = FALSE)}, the message to
+download the latest version will be disabled for the current R session.}
 
 \item{overwrite}{a \code{logical}. If \code{TRUE} it will override the downloaded
 files of the FORCIS database. Default is \code{FALSE}.}

--- a/man/read_data.Rd
+++ b/man/read_data.Rd
@@ -13,31 +13,31 @@
 read_cpr_north_data(
   path = ".",
   version = options()$forcis_version,
-  check_for_update = options()$check_for_update
+  check_for_update = options()$forcis_check_for_update
 )
 
 read_cpr_south_data(
   path = ".",
   version = options()$forcis_version,
-  check_for_update = options()$check_for_update
+  check_for_update = options()$forcis_check_for_update
 )
 
 read_plankton_nets_data(
   path = ".",
   version = options()$forcis_version,
-  check_for_update = options()$check_for_update
+  check_for_update = options()$forcis_check_for_update
 )
 
 read_pump_data(
   path = ".",
   version = options()$forcis_version,
-  check_for_update = options()$check_for_update
+  check_for_update = options()$forcis_check_for_update
 )
 
 read_sediment_trap_data(
   path = ".",
   version = options()$forcis_version,
-  check_for_update = options()$check_for_update
+  check_for_update = options()$forcis_check_for_update
 )
 }
 \arguments{
@@ -53,11 +53,11 @@ for the current R session. Note that it is recommended to use the latest
 version of the database.}
 
 \item{check_for_update}{a \code{logical}. If \code{TRUE} (default) the function will
-check if a newer version of the FORCIS database is available on Zenodo and
-will print an informative message. Note that this argument can be handle
-with the global option \code{check_for_update}. For example, if user calls
-\code{options(check_for_update = FALSE)}, the message to download the latest
-version will be disabled for the current R session.}
+check if a newer version of the FORCIS database is available on Zenodo
+and will print an informative message. Note that this argument can be
+handle with the global option \code{forcis_check_for_update}. For example, if
+user calls \code{options(forcis_check_for_update = FALSE)}, the message to
+download the latest version will be disabled for the current R session.}
 }
 \value{
 A \code{data.frame}. See

--- a/vignettes/database-versions.Rmd
+++ b/vignettes/database-versions.Rmd
@@ -10,9 +10,9 @@ vignette: >
 ```{r, include = FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
-  eval     = FALSE,
-  echo     = TRUE,
-  comment  = "#>"
+  eval = FALSE,
+  echo = TRUE,
+  comment = "#>"
 )
 ```
 
@@ -42,12 +42,12 @@ Note that the FORCIS database is saved in `forcis-db/version-99/`, where `99` is
 
 ## Using a specific version
 
-If for some reason users want to freeze the version they use, it is possible to disable this message by setting the argument `check_for_update` to `FALSE` in the `read_*_data()` functions.
+If for some reason users want to freeze the version they use, it is possible to disable this message by setting the argument `forcis_check_for_update` to `FALSE` in the `read_*_data()` functions.
 
 It is also possible to disable this message globally for the current session:
 
 ```{r 'disable-message'}
-options(check_for_update = FALSE)
+options(forcis_check_for_update = FALSE)
 ```
 
 The package `forcis` _"knows"_ which version of the database you used last time. A hidden file named `.forcis` is created (or updated) each time the function `download_forcis_db()` or `read_*_data()` is called. This hidden file contains one line:


### PR DESCRIPTION
This PR fixes #74 by adding the prefix `forcis_` to the global option `check_for_update` as it is for `forcis_version`.