### PR TITLE
rOpenSci review: Clean examples

### DIFF
--- a/R/convert_to_long_format.R
+++ b/R/convert_to_long_format.R
@@ -19,9 +19,6 @@
 #'
 #' net_data <- read.table(file_name, dec = ".", sep = ";")
 #'
-#' # Add 'data_type' column ----
-#' net_data$"data_type" <- "Net"
-#'
 #' # Dimensions of the data.frame ----
 #' dim(net_data)
 #'

--- a/R/convert_to_long_format.R
+++ b/R/convert_to_long_format.R
@@ -13,9 +13,6 @@
 #' @export
 #'
 #' @examples
-#' # Attach the package ----
-#' library("forcis")
-#'
 #' # Import example dataset ----
 #' file_name <- system.file(file.path("extdata", "FORCIS_net_sample.csv"),
 #'                          package = "forcis")

--- a/R/data_to_sf.R
+++ b/R/data_to_sf.R
@@ -13,8 +13,7 @@
 #' @export
 #'
 #' @examples
-#' # Attach packages ----
-#' library("forcis")
+#' # Attach package ----
 #' library("ggplot2")
 #'
 #' # Import example dataset ----

--- a/R/data_to_sf.R
+++ b/R/data_to_sf.R
@@ -22,9 +22,6 @@
 #'
 #' net_data <- read.table(file_name, dec = ".", sep = ";")
 #'
-#' # Add 'data_type' column ----
-#' net_data$"data_type" <- "Net"
-#'
 #' # Dimensions of the data.frame ----
 #' dim(net_data)
 #'

--- a/R/download_forcis_db.R
+++ b/R/download_forcis_db.R
@@ -55,9 +55,6 @@
 #'
 #' @examples
 #' \dontrun{
-#' # Attach the package ----
-#' library("forcis")
-#'
 #' # Folder in which the database will be saved ----
 #' path_to_save_db <- "data"
 #'

--- a/R/filter_by_bbox.R
+++ b/R/filter_by_bbox.R
@@ -19,9 +19,6 @@
 #' @export
 #'
 #' @examples
-#' # Attach the package ----
-#' library("forcis")
-#'
 #' # Import example dataset ----
 #' file_name <- system.file(file.path("extdata", "FORCIS_net_sample.csv"),
 #'                          package = "forcis")

--- a/R/filter_by_bbox.R
+++ b/R/filter_by_bbox.R
@@ -25,9 +25,6 @@
 #'
 #' net_data <- read.table(file_name, dec = ".", sep = ";")
 #'
-#' # Add 'data_type' column ----
-#' net_data$"data_type" <- "Net"
-#'
 #' # Dimensions of the data.frame ----
 #' dim(net_data)
 #'

--- a/R/filter_by_month.R
+++ b/R/filter_by_month.R
@@ -19,9 +19,6 @@
 #'
 #' net_data <- read.table(file_name, dec = ".", sep = ";")
 #'
-#' # Add 'data_type' column ----
-#' net_data$"data_type" <- "Net"
-#'
 #' # Dimensions of the data.frame ----
 #' dim(net_data)
 #'

--- a/R/filter_by_month.R
+++ b/R/filter_by_month.R
@@ -13,9 +13,6 @@
 #' @export
 #'
 #' @examples
-#' # Attach the package ----
-#' library("forcis")
-#'
 #' # Import example dataset ----
 #' file_name <- system.file(file.path("extdata", "FORCIS_net_sample.csv"),
 #'                          package = "forcis")

--- a/R/filter_by_ocean.R
+++ b/R/filter_by_ocean.R
@@ -20,9 +20,6 @@
 #'
 #' net_data <- read.table(file_name, dec = ".", sep = ";")
 #'
-#' # Add 'data_type' column ----
-#' net_data$"data_type" <- "Net"
-#'
 #' # Dimensions of the data.frame ----
 #' dim(net_data)
 #'

--- a/R/filter_by_ocean.R
+++ b/R/filter_by_ocean.R
@@ -14,9 +14,6 @@
 #' @export
 #'
 #' @examples
-#' # Attach the package ----
-#' library("forcis")
-#'
 #' # Import example dataset ----
 #' file_name <- system.file(file.path("extdata", "FORCIS_net_sample.csv"),
 #'                          package = "forcis")

--- a/R/filter_by_polygon.R
+++ b/R/filter_by_polygon.R
@@ -20,9 +20,6 @@
 #'
 #' net_data <- read.table(file_name, dec = ".", sep = ";")
 #'
-#' # Add 'data_type' column ----
-#' net_data$"data_type" <- "Net"
-#'
 #' # Dimensions of the data.frame ----
 #' dim(net_data)
 #'

--- a/R/filter_by_polygon.R
+++ b/R/filter_by_polygon.R
@@ -14,9 +14,6 @@
 #' @export
 #'
 #' @examples
-#' # Attach the package ----
-#' library("forcis")
-#'
 #' # Import example dataset ----
 #' file_name <- system.file(file.path("extdata", "FORCIS_net_sample.csv"),
 #'                          package = "forcis")

--- a/R/filter_by_species.R
+++ b/R/filter_by_species.R
@@ -19,9 +19,6 @@
 #'
 #' net_data <- read.table(file_name, dec = ".", sep = ";")
 #'
-#' # Add 'data_type' column ----
-#' net_data$"data_type" <- "Net"
-#'
 #' # Select a taxonomy ----
 #' net_data <- select_taxonomy(net_data, taxonomy = "VT")
 #'

--- a/R/filter_by_year.R
+++ b/R/filter_by_year.R
@@ -19,9 +19,6 @@
 #'
 #' net_data <- read.table(file_name, dec = ".", sep = ";")
 #'
-#' # Add 'data_type' column ----
-#' net_data$"data_type" <- "Net"
-#'
 #' # Dimensions of the data.frame ----
 #' dim(net_data)
 #'

--- a/R/filter_by_year.R
+++ b/R/filter_by_year.R
@@ -13,9 +13,6 @@
 #' @export
 #'
 #' @examples
-#' # Attach the package ----
-#' library("forcis")
-#'
 #' # Import example dataset ----
 #' file_name <- system.file(file.path("extdata", "FORCIS_net_sample.csv"),
 #'                          package = "forcis")

--- a/R/geom_basemap.R
+++ b/R/geom_basemap.R
@@ -11,8 +11,7 @@
 #' @export
 #'
 #' @examples
-#' # Attach packages ----
-#' library("forcis")
+#' # Attach package ----
 #' library("ggplot2")
 #'
 #' # World basemap ----

--- a/R/get_available_versions.R
+++ b/R/get_available_versions.R
@@ -12,8 +12,10 @@
 #' @export
 #'
 #' @examples
+#' \dontrun{
 #' # Versions of the FORCIS database ----
 #' get_available_versions()
+#' }
 
 get_available_versions <- function() {
   ## Retrieve information ----

--- a/R/get_available_versions.R
+++ b/R/get_available_versions.R
@@ -12,9 +12,6 @@
 #' @export
 #'
 #' @examples
-#' # Attach the package ----
-#' library("forcis")
-#'
 #' # Versions of the FORCIS database ----
 #' get_available_versions()
 

--- a/R/get_ocean_names.R
+++ b/R/get_ocean_names.R
@@ -14,9 +14,8 @@
 #' DOI: \url{https://doi.org/10.14284/323}.
 #'
 #' @examples
-#' \dontrun{
+#' # Print the name of World oceans ----
 #' get_ocean_names()
-#' }
 
 get_ocean_names <- function() {
   iho_boundaries$"NAME"

--- a/R/get_species_names.R
+++ b/R/get_species_names.R
@@ -12,19 +12,17 @@
 #' @return A `character` vector of species names.
 #'
 #' @examples
-#' \dontrun{
-#' # Folder in which the database is stored ----
-#' path_to_db <- "data"
+#' # Import example dataset ----
+#' file_name <- system.file(file.path("extdata", "FORCIS_net_sample.csv"),
+#'                          package = "forcis")
 #'
-#' # Download and read the plankton nets data ----
-#' plankton_nets_data <- read_plankton_nets_data(path_to_db)
+#' net_data <- read.table(file_name, dec = ".", sep = ";")
 #'
 #' # Select a taxonomy ----
-#' plankton_nets_data <- select_taxonomy(plankton_nets_data, taxonomy = "OT")
+#' net_data <- select_taxonomy(net_data, taxonomy = "VT")
 #'
 #' # Retrieve taxon names ----
-#' get_species_names(nets)
-#' }
+#' get_species_names(net_data)
 
 get_species_names <- function(data) {
   check_if_df(data)

--- a/R/get_version_metadata.R
+++ b/R/get_version_metadata.R
@@ -15,9 +15,6 @@
 #' @export
 #'
 #' @examples
-#' # Attach the package ----
-#' library("forcis")
-#'
 #' # Get information for the latest version of the FORCIS database ----
 #' get_version_metadata()
 

--- a/R/get_version_metadata.R
+++ b/R/get_version_metadata.R
@@ -15,8 +15,10 @@
 #' @export
 #'
 #' @examples
+#' \dontrun{
 #' # Get information for the latest version of the FORCIS database ----
 #' get_version_metadata()
+#' }
 
 get_version_metadata <- function(version = NULL) {
   ## Check arguments ----

--- a/R/ggmap_data.R
+++ b/R/ggmap_data.R
@@ -14,9 +14,6 @@
 #' @export
 #'
 #' @examples
-#' # Attach the package ----
-#' library("forcis")
-#'
 #' # Import example dataset ----
 #' file_name <- system.file(file.path("extdata", "FORCIS_net_sample.csv"),
 #'                          package = "forcis")

--- a/R/ggmap_data.R
+++ b/R/ggmap_data.R
@@ -20,9 +20,6 @@
 #'
 #' net_data <- read.table(file_name, dec = ".", sep = ";")
 #'
-#' # Add 'data_type' column ----
-#' net_data$"data_type" <- "Net"
-#'
 #' # Map data (default) ----
 #' ggmap_data(net_data)
 #'

--- a/R/plot_record_by_depth.R
+++ b/R/plot_record_by_depth.R
@@ -10,9 +10,6 @@
 #' @export
 #'
 #' @examples
-#' # Attach the package ----
-#' library("forcis")
-#'
 #' # Import example dataset ----
 #' file_name <- system.file(file.path("extdata", "FORCIS_net_sample.csv"),
 #'                          package = "forcis")

--- a/R/plot_record_by_month.R
+++ b/R/plot_record_by_month.R
@@ -10,9 +10,6 @@
 #' @export
 #'
 #' @examples
-#' # Attach the package ----
-#' library("forcis")
-#'
 #' # Import example dataset ----
 #' file_name <- system.file(file.path("extdata", "FORCIS_net_sample.csv"),
 #'                          package = "forcis")

--- a/R/plot_record_by_season.R
+++ b/R/plot_record_by_season.R
@@ -10,9 +10,6 @@
 #' @export
 #'
 #' @examples
-#' # Attach the package ----
-#' library("forcis")
-#'
 #' # Import example dataset ----
 #' file_name <- system.file(file.path("extdata", "FORCIS_net_sample.csv"),
 #'                          package = "forcis")

--- a/R/plot_record_by_year.R
+++ b/R/plot_record_by_year.R
@@ -10,9 +10,6 @@
 #' @export
 #'
 #' @examples
-#' # Attach the package ----
-#' library("forcis")
-#'
 #' # Import example dataset ----
 #' file_name <- system.file(file.path("extdata", "FORCIS_net_sample.csv"),
 #'                          package = "forcis")

--- a/R/read_plankton_nets_data.R
+++ b/R/read_plankton_nets_data.R
@@ -28,9 +28,6 @@
 #'
 #' @examples
 #' \dontrun{
-#' # Attach the package ----
-#' library("forcis")
-#'
 #' # Folder in which the database will be saved ----
 #' path_to_save_db <- "data"
 #'

--- a/R/select_forcis_columns.R
+++ b/R/select_forcis_columns.R
@@ -17,9 +17,6 @@
 #' @return A `tibble`.
 #'
 #' @examples
-#' # Attach the package ----
-#' library("forcis")
-#'
 #' # Import example dataset ----
 #' file_name <- system.file(file.path("extdata", "FORCIS_net_sample.csv"),
 #'                          package = "forcis")

--- a/R/select_forcis_columns.R
+++ b/R/select_forcis_columns.R
@@ -23,9 +23,6 @@
 #'
 #' net_data <- read.table(file_name, dec = ".", sep = ";")
 #'
-#' # Add 'data_type' column ----
-#' net_data$"data_type" <- "Net"
-#'
 #' # Dimensions of the data.frame ----
 #' dim(net_data)
 #'

--- a/R/select_taxonomy.R
+++ b/R/select_taxonomy.R
@@ -22,9 +22,6 @@
 #'
 #' net_data <- read.table(file_name, dec = ".", sep = ";")
 #'
-#' # Add 'data_type' column ----
-#' net_data$"data_type" <- "Net"
-#'
 #' # Dimensions of the data.frame ----
 #' dim(net_data)
 #'

--- a/R/select_taxonomy.R
+++ b/R/select_taxonomy.R
@@ -16,9 +16,6 @@
 #' @return A `tibble`.
 #'
 #' @examples
-#' # Attach the package ----
-#' library("forcis")
-#'
 #' # Import example dataset ----
 #' file_name <- system.file(file.path("extdata", "FORCIS_net_sample.csv"),
 #'                          package = "forcis")

--- a/man/convert_to_long_format.Rd
+++ b/man/convert_to_long_format.Rd
@@ -25,9 +25,6 @@ file_name <- system.file(file.path("extdata", "FORCIS_net_sample.csv"),
 
 net_data <- read.table(file_name, dec = ".", sep = ";")
 
-# Add 'data_type' column ----
-net_data$"data_type" <- "Net"
-
 # Dimensions of the data.frame ----
 dim(net_data)
 

--- a/man/convert_to_long_format.Rd
+++ b/man/convert_to_long_format.Rd
@@ -19,9 +19,6 @@ Reshapes FORCIS data by pivoting species columns into two columns: \code{taxa}
 to a long format.
 }
 \examples{
-# Attach the package ----
-library("forcis")
-
 # Import example dataset ----
 file_name <- system.file(file.path("extdata", "FORCIS_net_sample.csv"),
                          package = "forcis")

--- a/man/data_to_sf.Rd
+++ b/man/data_to_sf.Rd
@@ -19,8 +19,7 @@ Note that coordinates (columns \code{site_lon_start_decimal} and
 \code{site_lat_start_decimal}) are projected in the Robinson coordinate system.
 }
 \examples{
-# Attach packages ----
-library("forcis")
+# Attach package ----
 library("ggplot2")
 
 # Import example dataset ----

--- a/man/data_to_sf.Rd
+++ b/man/data_to_sf.Rd
@@ -28,9 +28,6 @@ file_name <- system.file(file.path("extdata", "FORCIS_net_sample.csv"),
 
 net_data <- read.table(file_name, dec = ".", sep = ";")
 
-# Add 'data_type' column ----
-net_data$"data_type" <- "Net"
-
 # Dimensions of the data.frame ----
 dim(net_data)
 

--- a/man/download_forcis_db.Rd
+++ b/man/download_forcis_db.Rd
@@ -59,9 +59,6 @@ For more information, please read the vignette available at
 }
 \examples{
 \dontrun{
-# Attach the package ----
-library("forcis")
-
 # Folder in which the database will be saved ----
 path_to_save_db <- "data"
 

--- a/man/filter_by_bbox.Rd
+++ b/man/filter_by_bbox.Rd
@@ -25,9 +25,6 @@ box.
 Filters FORCIS data by a spatial bounding box.
 }
 \examples{
-# Attach the package ----
-library("forcis")
-
 # Import example dataset ----
 file_name <- system.file(file.path("extdata", "FORCIS_net_sample.csv"),
                          package = "forcis")

--- a/man/filter_by_bbox.Rd
+++ b/man/filter_by_bbox.Rd
@@ -31,9 +31,6 @@ file_name <- system.file(file.path("extdata", "FORCIS_net_sample.csv"),
 
 net_data <- read.table(file_name, dec = ".", sep = ";")
 
-# Add 'data_type' column ----
-net_data$"data_type" <- "Net"
-
 # Dimensions of the data.frame ----
 dim(net_data)
 

--- a/man/filter_by_month.Rd
+++ b/man/filter_by_month.Rd
@@ -25,9 +25,6 @@ file_name <- system.file(file.path("extdata", "FORCIS_net_sample.csv"),
 
 net_data <- read.table(file_name, dec = ".", sep = ";")
 
-# Add 'data_type' column ----
-net_data$"data_type" <- "Net"
-
 # Dimensions of the data.frame ----
 dim(net_data)
 

--- a/man/filter_by_month.Rd
+++ b/man/filter_by_month.Rd
@@ -19,9 +19,6 @@ A \code{tibble} containing a subset of \code{data} for the desired months.
 Filters FORCIS data by month of sampling.
 }
 \examples{
-# Attach the package ----
-library("forcis")
-
 # Import example dataset ----
 file_name <- system.file(file.path("extdata", "FORCIS_net_sample.csv"),
                          package = "forcis")

--- a/man/filter_by_ocean.Rd
+++ b/man/filter_by_ocean.Rd
@@ -26,9 +26,6 @@ file_name <- system.file(file.path("extdata", "FORCIS_net_sample.csv"),
 
 net_data <- read.table(file_name, dec = ".", sep = ";")
 
-# Add 'data_type' column ----
-net_data$"data_type" <- "Net"
-
 # Dimensions of the data.frame ----
 dim(net_data)
 

--- a/man/filter_by_ocean.Rd
+++ b/man/filter_by_ocean.Rd
@@ -20,9 +20,6 @@ A \code{tibble} containing a subset of \code{data} for the desired oceans.
 Filters FORCIS data by one or several oceans.
 }
 \examples{
-# Attach the package ----
-library("forcis")
-
 # Import example dataset ----
 file_name <- system.file(file.path("extdata", "FORCIS_net_sample.csv"),
                          package = "forcis")

--- a/man/filter_by_polygon.Rd
+++ b/man/filter_by_polygon.Rd
@@ -26,9 +26,6 @@ file_name <- system.file(file.path("extdata", "FORCIS_net_sample.csv"),
 
 net_data <- read.table(file_name, dec = ".", sep = ";")
 
-# Add 'data_type' column ----
-net_data$"data_type" <- "Net"
-
 # Dimensions of the data.frame ----
 dim(net_data)
 

--- a/man/filter_by_polygon.Rd
+++ b/man/filter_by_polygon.Rd
@@ -20,9 +20,6 @@ polygon.
 Filters FORCIS data by a spatial polygon.
 }
 \examples{
-# Attach the package ----
-library("forcis")
-
 # Import example dataset ----
 file_name <- system.file(file.path("extdata", "FORCIS_net_sample.csv"),
                          package = "forcis")

--- a/man/filter_by_species.Rd
+++ b/man/filter_by_species.Rd
@@ -25,9 +25,6 @@ file_name <- system.file(file.path("extdata", "FORCIS_net_sample.csv"),
 
 net_data <- read.table(file_name, dec = ".", sep = ";")
 
-# Add 'data_type' column ----
-net_data$"data_type" <- "Net"
-
 # Select a taxonomy ----
 net_data <- select_taxonomy(net_data, taxonomy = "VT")
 

--- a/man/filter_by_year.Rd
+++ b/man/filter_by_year.Rd
@@ -19,9 +19,6 @@ A \code{tibble} containing a subset of \code{data} for the desired years.
 Filters FORCIS data by year of sampling.
 }
 \examples{
-# Attach the package ----
-library("forcis")
-
 # Import example dataset ----
 file_name <- system.file(file.path("extdata", "FORCIS_net_sample.csv"),
                          package = "forcis")

--- a/man/filter_by_year.Rd
+++ b/man/filter_by_year.Rd
@@ -25,9 +25,6 @@ file_name <- system.file(file.path("extdata", "FORCIS_net_sample.csv"),
 
 net_data <- read.table(file_name, dec = ".", sep = ";")
 
-# Add 'data_type' column ----
-net_data$"data_type" <- "Net"
-
 # Dimensions of the data.frame ----
 dim(net_data)
 

--- a/man/geom_basemap.Rd
+++ b/man/geom_basemap.Rd
@@ -16,8 +16,7 @@ Spatial layers come from the Natural Earth project
 coordinate system.
 }
 \examples{
-# Attach packages ----
-library("forcis")
+# Attach package ----
 library("ggplot2")
 
 # World basemap ----

--- a/man/get_available_versions.Rd
+++ b/man/get_available_versions.Rd
@@ -19,6 +19,8 @@ Gets all available versions of the FORCIS database by querying the Zenodo API
 (\url{https://developers.zenodo.org}).
 }
 \examples{
+\dontrun{
 # Versions of the FORCIS database ----
 get_available_versions()
+}
 }

--- a/man/get_available_versions.Rd
+++ b/man/get_available_versions.Rd
@@ -19,9 +19,6 @@ Gets all available versions of the FORCIS database by querying the Zenodo API
 (\url{https://developers.zenodo.org}).
 }
 \examples{
-# Attach the package ----
-library("forcis")
-
 # Versions of the FORCIS database ----
 get_available_versions()
 }

--- a/man/get_ocean_names.Rd
+++ b/man/get_ocean_names.Rd
@@ -14,9 +14,8 @@ This function returns the name of World oceans according to the IHO Sea Areas
 dataset version 3 (Flanders Marine Institute, 2018).
 }
 \examples{
-\dontrun{
+# Print the name of World oceans ----
 get_ocean_names()
-}
 }
 \references{
 Flanders Marine Institute (2018). IHO Sea Areas, version 3.

--- a/man/get_species_names.Rd
+++ b/man/get_species_names.Rd
@@ -18,17 +18,15 @@ Gets species names from column names. This function is just an utility to
 easily retrieve taxon names.
 }
 \examples{
-\dontrun{
-# Folder in which the database is stored ----
-path_to_db <- "data"
+# Import example dataset ----
+file_name <- system.file(file.path("extdata", "FORCIS_net_sample.csv"),
+                         package = "forcis")
 
-# Download and read the plankton nets data ----
-plankton_nets_data <- read_plankton_nets_data(path_to_db)
+net_data <- read.table(file_name, dec = ".", sep = ";")
 
 # Select a taxonomy ----
-plankton_nets_data <- select_taxonomy(plankton_nets_data, taxonomy = "OT")
+net_data <- select_taxonomy(net_data, taxonomy = "VT")
 
 # Retrieve taxon names ----
-get_species_names(nets)
-}
+get_species_names(net_data)
 }

--- a/man/get_version_metadata.Rd
+++ b/man/get_version_metadata.Rd
@@ -21,6 +21,8 @@ Prints information of a specific version of the FORCIS database by querying
 the Zenodo API (\url{https://developers.zenodo.org}).
 }
 \examples{
+\dontrun{
 # Get information for the latest version of the FORCIS database ----
 get_version_metadata()
+}
 }

--- a/man/get_version_metadata.Rd
+++ b/man/get_version_metadata.Rd
@@ -21,9 +21,6 @@ Prints information of a specific version of the FORCIS database by querying
 the Zenodo API (\url{https://developers.zenodo.org}).
 }
 \examples{
-# Attach the package ----
-library("forcis")
-
 # Get information for the latest version of the FORCIS database ----
 get_version_metadata()
 }

--- a/man/ggmap_data.Rd
+++ b/man/ggmap_data.Rd
@@ -26,9 +26,6 @@ file_name <- system.file(file.path("extdata", "FORCIS_net_sample.csv"),
 
 net_data <- read.table(file_name, dec = ".", sep = ";")
 
-# Add 'data_type' column ----
-net_data$"data_type" <- "Net"
-
 # Map data (default) ----
 ggmap_data(net_data)
 

--- a/man/ggmap_data.Rd
+++ b/man/ggmap_data.Rd
@@ -20,9 +20,6 @@ A \code{ggplot} object.
 Maps the spatial distribution of FORCIS data.
 }
 \examples{
-# Attach the package ----
-library("forcis")
-
 # Import example dataset ----
 file_name <- system.file(file.path("extdata", "FORCIS_net_sample.csv"),
                          package = "forcis")

--- a/man/plot_record_by_depth.Rd
+++ b/man/plot_record_by_depth.Rd
@@ -16,9 +16,6 @@ A \code{ggplot} object.
 This function produces a barplot of FORCIS sample records by depth.
 }
 \examples{
-# Attach the package ----
-library("forcis")
-
 # Import example dataset ----
 file_name <- system.file(file.path("extdata", "FORCIS_net_sample.csv"),
                          package = "forcis")

--- a/man/plot_record_by_month.Rd
+++ b/man/plot_record_by_month.Rd
@@ -16,9 +16,6 @@ A \code{ggplot} object.
 This function produces a barplot of FORCIS sample records by month.
 }
 \examples{
-# Attach the package ----
-library("forcis")
-
 # Import example dataset ----
 file_name <- system.file(file.path("extdata", "FORCIS_net_sample.csv"),
                          package = "forcis")

--- a/man/plot_record_by_season.Rd
+++ b/man/plot_record_by_season.Rd
@@ -16,9 +16,6 @@ A \code{ggplot} object.
 This function produces a barplot of FORCIS sample records by season.
 }
 \examples{
-# Attach the package ----
-library("forcis")
-
 # Import example dataset ----
 file_name <- system.file(file.path("extdata", "FORCIS_net_sample.csv"),
                          package = "forcis")

--- a/man/plot_record_by_year.Rd
+++ b/man/plot_record_by_year.Rd
@@ -16,9 +16,6 @@ A \code{ggplot} object.
 This function produces a barplot of FORCIS sample records by year.
 }
 \examples{
-# Attach the package ----
-library("forcis")
-
 # Import example dataset ----
 file_name <- system.file(file.path("extdata", "FORCIS_net_sample.csv"),
                          package = "forcis")

--- a/man/read_data.Rd
+++ b/man/read_data.Rd
@@ -80,9 +80,6 @@ must be used first to store locally the database.
 }
 \examples{
 \dontrun{
-# Attach the package ----
-library("forcis")
-
 # Folder in which the database will be saved ----
 path_to_save_db <- "data"
 

--- a/man/select_forcis_columns.Rd
+++ b/man/select_forcis_columns.Rd
@@ -29,9 +29,6 @@ file_name <- system.file(file.path("extdata", "FORCIS_net_sample.csv"),
 
 net_data <- read.table(file_name, dec = ".", sep = ";")
 
-# Add 'data_type' column ----
-net_data$"data_type" <- "Net"
-
 # Dimensions of the data.frame ----
 dim(net_data)
 

--- a/man/select_forcis_columns.Rd
+++ b/man/select_forcis_columns.Rd
@@ -23,9 +23,6 @@ columns, this function can be used to lighten the \code{data.frame} to easily
 handle it and to speed up some computations.
 }
 \examples{
-# Attach the package ----
-library("forcis")
-
 # Import example dataset ----
 file_name <- system.file(file.path("extdata", "FORCIS_net_sample.csv"),
                          package = "forcis")

--- a/man/select_taxonomy.Rd
+++ b/man/select_taxonomy.Rd
@@ -22,9 +22,6 @@ taxonomies: \code{"LT"} (lumped taxonomy), \code{"VT"} (validated taxonomy) and 
 further information.
 }
 \examples{
-# Attach the package ----
-library("forcis")
-
 # Import example dataset ----
 file_name <- system.file(file.path("extdata", "FORCIS_net_sample.csv"),
                          package = "forcis")

--- a/man/select_taxonomy.Rd
+++ b/man/select_taxonomy.Rd
@@ -28,9 +28,6 @@ file_name <- system.file(file.path("extdata", "FORCIS_net_sample.csv"),
 
 net_data <- read.table(file_name, dec = ".", sep = ";")
 
-# Add 'data_type' column ----
-net_data$"data_type" <- "Net"
-
 # Dimensions of the data.frame ----
 dim(net_data)
 


### PR DESCRIPTION
This PR fixes #98 

- Remove `library("forcis")`
- Remove some `\dontrun{}` examples
- Disable some examples (using the Zenodo API)
- Remove the line `net_data$"data_type" <- "Net"` as it is not necessary