### PR TITLE
rOpenSci review: Add reviewer 2 in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,6 +32,11 @@ Authors@R: c(
            family  = "Hammami",
            role    = "ctb",
            email   = "khalil.hammami@enetcom.usf.tn"),
+    person(given   = "Air",
+           family  = "Forbes",
+           role    = "rev",
+           email   = "amforbes@ualberta.ca",
+           comment = c(ORCID = "0000-0002-9842-7648")),
     person(given   = "FRB-CESAB",
            role    = "fnd"))
 Description: Provides an interface to the FORCIS database 

--- a/man/forcis-package.Rd
+++ b/man/forcis-package.Rd
@@ -32,6 +32,7 @@ Authors:
 Other contributors:
 \itemize{
   \item Khalil Hammami \email{khalil.hammami@enetcom.usf.tn} [contributor]
+  \item Air Forbes \email{amforbes@ualberta.ca} (\href{https://orcid.org/0000-0002-9842-7648}{ORCID}) [reviewer]
   \item FRB-CESAB [funder]
 }
 


### PR DESCRIPTION
As requested in the [review](), this PR adds @heyairf in the `DESCRIPTION` file as `rev`iewer